### PR TITLE
Back-patch to 7.x to allow analyzer v0.40.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # 7.1.1
 
 - Support analyzer `^0.40.0`.
+- Workaround https://github.com/google/built_value.dart/issues/941.
 
 # 7.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 7.1.1
+
+- Support analyzer `^0.40.0`.
+
 # 7.1.0
 
 - Support private `Built` classes. Note that private classes cannot be made
@@ -547,7 +551,7 @@ Fixes:
 
 ## 1.0.0
 
-- Version bump to 1.0.0. Three minor features are marked as experimental and 
+- Version bump to 1.0.0. Three minor features are marked as experimental and
   may change without a major version increase: BuiltValueToStringHelper,
   JsonObject and SerializerPlugin.
 - Made toString() output customizable.
@@ -562,7 +566,7 @@ Fixes:
 
 - Add serializer for "DateTime" fields.
 - Add JsonObject class and serializer.
-- Add convenience methods Seralizers.serializeWith and deserializeWith. 
+- Add convenience methods Seralizers.serializeWith and deserializeWith.
 - Add example for using StandardJsonPlugin.
 - Support serializing NaN, INF and -INF for double and num.
 

--- a/built_value_generator/pubspec.yaml
+++ b/built_value_generator/pubspec.yaml
@@ -9,7 +9,11 @@ environment:
   sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=0.39.3 <0.40.0'
+  # This range allows consumption by packages that need more recent build_*
+  # versions without also requiring a newer Dart SDK version. The range is also
+  # safe, as code in this package analyzes cleanly and passes tests on both
+  # major versions of the analyzer.
+  analyzer: '>=0.39.3 <0.41.0'
   build: ^1.0.0
   build_config: '>=0.3.1 <0.5.0'
   built_collection: '>=2.0.0 <5.0.0'
@@ -19,7 +23,11 @@ dependencies:
 
 dev_dependencies:
   build_test: ^0.10.3
-  build_runner: ^1.0.0
+  # This range works around the InconsistentAnalysisException issue when
+  # building this package on newer versions of Dart, while still remaining
+  # compatible with the above analyzer range.
+  # See https://github.com/google/built_value.dart/issues/941#issuecomment-737884696
+  build_runner: '>=1.0.0 <=1.10.2'
   logging: ^0.11.0
   pedantic: ^1.4.0
   test: ^1.0.0


### PR DESCRIPTION
The built_value_generator package at version 7.1.0 depends on `analyzer: '>=0.39.3 <0.40.0'`, which prevents consumers from resolving newer versions of certain build packages. However, built_value_generator is completely compatible with analyzer v0.40.x as-is. So, to allow consumption of built_value* 7.x with newer build packages without also having to upgrade to Dart 2.12+, this commit widens the analyzer range to include v0.40.x.

I've verified locally that on both Dart 2.7.2 and 2.13.4:
- `pub get` resolves
- `./tool/presubmit` builds all packages successfully
- `pub run test` passes on `built_value_generator`

---

Some context: Workiva is about to upgrade from Dart 2.7 to 2.13 (for a few reasons, we were unable to upgrade to versions prior to 2.12). So far, we've been able to upgrade all of our individual packages to run on 2.13 successfully while still supporting dependency ranges that resolve on both 2.7 and 2.13. This buys us the ability to build our main application on both versions and switch which version is deployed with a flag.

One of the critical dependency versions that we need to resolve to on 2.13 is `build_web_compilers v2.12.0`, because prior to this version, code is incorrectly opted-in to NNBD even though the package's minimum Dart SDK is less than 2.12. Unfortunately, `built_value_generator v7.1.0` prevents us from resolving to that version because of its analyzer dependency. Because of that, we had been using a `>=7.1.0 <9.0.0` range which we've now learned is unsafe because code generated with built_value_generator v8 (reasonably) references code that does not exist in built_value v7.

If this is an acceptable back-patch, we would be able to depend on built_value and built_value_generator `^7.1.1` _and_ resolve `build_web_compilers 2.12.0` on Dart 2.13, which means we'd be able to complete this upgrade smoothly.

@davidmorgan is this something you'd be open to?